### PR TITLE
Add .ipuz export

### DIFF
--- a/genxword/calculate.py
+++ b/genxword/calculate.py
@@ -24,7 +24,7 @@ gi.require_version('PangoCairo', '1.0')
 gi.require_version('Pango', '1.0')
 
 from gi.repository import Pango, PangoCairo
-import random, time, cairo
+import random, time, cairo, json
 from operator import itemgetter
 from collections import defaultdict
 
@@ -296,6 +296,10 @@ class Exportfiles(object):
         if 'n' in save_format or 's' in save_format:
             self.clues_txt(name + '_clues.txt', lang)
             img_files += name + '_clues.txt'
+        if 'z' in save_format:
+            out = name + '.ipuz'
+            self.write_puz(name=name, filename=out, lang=lang)
+            img_files += out
         if message:
             print(message + img_files)
 
@@ -334,3 +338,40 @@ class Exportfiles(object):
         with open(name, 'w') as clues_file:
             clues_file.write(self.word_bank())
             clues_file.write(self.legend(lang))
+
+    def write_puz(self, name, filename, lang):
+        # Generate the clue numbers if we haven't already
+        if len(self.wordlist[0]) < 6:
+            self.order_number_words()
+
+        # Generate some data structures for the final output
+        puzzle = [[0] * self.cols for row in range(self.rows)]
+        clues = {'Across': [], 'Down': []}
+        solution = [['#' if col == '-' else col for col in row] for row in self.grid]
+
+        # Iterate the clues to calculate the main data
+        for clue in self.wordlist:
+            word, clue_text, row, col, vertical, num = clue[:6]
+            puzzle[row][col] = num
+
+            puz_clue = [num, clue_text]
+            if vertical:
+                clues['Down'].append(puz_clue)
+            else:
+                clues['Across'].append(puz_clue)
+
+        data = {
+            'dimensions': {
+                'width': self.cols,
+                'height': self.rows
+            },
+            'puzzle': puzzle,
+            'clues': clues,
+            'solution': solution,
+            'version': 'http://ipuz.org/v1',
+            'kind': ['http://ipuz.org/crossword#1'],
+            'title': name,
+        }
+
+        with open(filename, 'w') as fp:
+            json.dump(data, fp)

--- a/genxword/calculate.py
+++ b/genxword/calculate.py
@@ -374,4 +374,4 @@ class Exportfiles(object):
         }
 
         with open(filename, 'w') as fp:
-            json.dump(data, fp)
+            json.dump(data, fp, indent=4)

--- a/genxword/calculate.py
+++ b/genxword/calculate.py
@@ -298,7 +298,7 @@ class Exportfiles(object):
             img_files += name + '_clues.txt'
         if 'z' in save_format:
             out = name + '.ipuz'
-            self.write_puz(name=name, filename=out, lang=lang)
+            self.write_ipuz(name=name, filename=out, lang=lang)
             img_files += out
         if message:
             print(message + img_files)
@@ -339,7 +339,7 @@ class Exportfiles(object):
             clues_file.write(self.word_bank())
             clues_file.write(self.legend(lang))
 
-    def write_puz(self, name, filename, lang):
+    def write_ipuz(self, name, filename, lang):
         # Generate the clue numbers if we haven't already
         if len(self.wordlist[0]) < 6:
             self.order_number_words()

--- a/genxword/cli.py
+++ b/genxword/cli.py
@@ -27,7 +27,8 @@ For further information on how to format the word list file and about the other 
 def main():
     parser = argparse.ArgumentParser(description=_('Crossword generator.'), prog='genxword', epilog=usage_info)
     parser.add_argument('infile', help=_('Name of word list file.'))
-    parser.add_argument('saveformat', help=_('Save files as A4 pdf (p), letter size pdf (l), png (n) and/or svg (s).'))
+    parser.add_argument('saveformat', help=_('Save files as A4 pdf (p), letter size pdf (l), png (n), svg(s) and/or '
+                                             'ipuz(z).'))
     parser.add_argument('-a', '--auto', dest='auto', action='store_true', help=_('Automated (non-interactive) option.'))
     parser.add_argument('-m', '--mix', dest='mixmode', action='store_true', help=_('Create anagrams for the clues'))
     parser.add_argument('-n', '--number', dest='nwords', type=int, default=50, help=_('Number of words to be used.'))

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,12 @@ setup(
     	'pycairo',
     	'PyGObject',
     ],
+    extras_require={
+        'dev': [
+            'pytest',
+            'ipuz'
+        ]
+    },
     entry_points={
         'console_scripts': [
             'genxword = genxword.cli:main',

--- a/test.py
+++ b/test.py
@@ -1,0 +1,22 @@
+import ipuz
+from genxword.control import _, Genxword
+import tempfile
+import os
+
+
+def test_ipuz_export():
+    with tempfile.TemporaryDirectory() as temp:
+        # Move to a temporary directory so we don't clog up anything important
+        os.chdir(temp)
+
+        # Generate a simple crossword as .puz
+        gen = Genxword(auto=True, mixmode=False)
+        gen.wlist([
+            'land', 'successful', 'climb', 'yet', 'picture', 'traffic', 'skin', 'leadership', 'threaten', 'win'
+        ], 10)
+        gen.grid_size()
+        gen.gengrid('test', 'z')
+
+        with open('test.ipuz') as fp:
+            # This does automatic validation
+            ipuz.read(''.join(fp.read()))

--- a/test.py
+++ b/test.py
@@ -1,5 +1,5 @@
 import ipuz
-from genxword.control import _, Genxword
+from genxword.control import Genxword
 import tempfile
 import os
 


### PR DESCRIPTION
## Motivation
Downstream uses of the puzzle data (for example, crossword apps) will want the puzzle in a structured format in order to import.

Currently there are 4 main well-defined crossword formats:
* [.puz](https://code.google.com/archive/p/puz/wikis/FileFormat.wiki) (binary and text subformats)
* [.ipuz](http://www.ipuz.org/)
* [.jpuz](http://wx-xword.sourceforge.net/crosswordsolver.html)
* [.xpf](https://www.xwordinfo.com/XPF/) (JSON and XML subformats)

Ideally genxword would support export in all of these formats, but I chose `ipuz` as the first option, because it has the best defined specification, and a Python validation library: https://github.com/svisser/ipuz.

## Changes
* This introduces a new ipuz export format, triggered by 'z' in the invocation
* Using this will produce `NAME.ipuz` as an additional output
* I've also added a single test function located in a new file, `test.py`
* In addition, I had to add a `dev` extra to the setup file, such that you can install the test dependencies with `pip install .[dev]`, and then `pytest test.py`