### PR TITLE
Some Fixes/Improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,20 +41,36 @@ Use
 Please read the `wiki <https://github.com/riverrun/genxword/wiki>`_ for
 information about how to use genxword.
 
-Installation
-------------
+GUI Installation
+----------------
 
 To install genxword (add *sudo* to the command, or run as root,
-if you are using Linux): ::
+if you are using Linux):
 
     pip3 install genxword
+
+Next, ensure you have installed all the necessary dependencies under #Dependencies.
+
+Lite Installation
+-----------------
+
+Simply run:
+
+   pip3 install genxword --no-deps
+
+Everything will work fine. However, you will only be able to export to:
+   t: Text,
+   z: IPUZ,
+   c: CSV,
+   j: Simplified JSON Representation
 
 Dependencies
 ------------
 
-Genxword depends on pycairo (python-cairo), pygobject (python-gobject or python-gi),
-python-gi-cairo (if you are using a Debian-based system), pango (gir1.2-pango-1.0),
-gtksourceview3 (gir1.2-gtksource-3.0) and gettext.
+Genxword requires pycairo (python-cairo), pygobject (python-gobject or python-gi),
+python-gi-cairo (if you are using a Debian-based system), and pango (gir1.2-pango-1.0).
+
+If you would like to use the GUI, install gtksourceview3 (gir1.2-gtksource-3.0) and gettext.
 
 These dependencies can easily be installed on Linux by using your package manager,
 and with most distributions, they will already be installed.

--- a/genxword/cli.py
+++ b/genxword/cli.py
@@ -27,13 +27,18 @@ For further information on how to format the word list file and about the other 
 def main():
     parser = argparse.ArgumentParser(description=_('Crossword generator.'), prog='genxword', epilog=usage_info)
     parser.add_argument('infile', help=_('Name of word list file.'))
-    parser.add_argument('saveformat', help=_('Save files as A4 pdf (p), letter size pdf (l), png (n), svg(s) and/or '
-                                             'ipuz(z).'))
+    filetypes = [c for c in 'plnszcjt']
+    parser.add_argument('saveformat', help=_('Save files as A4 PDF (p), Letter Size PDF (l), PNG (n), SVG (s), IPUZ (z),'
+                                             'Plain Text (t), CSV (c), and/or JSON (j).'))
     parser.add_argument('-a', '--auto', dest='auto', action='store_true', help=_('Automated (non-interactive) option.'))
     parser.add_argument('-m', '--mix', dest='mixmode', action='store_true', help=_('Create anagrams for the clues'))
     parser.add_argument('-n', '--number', dest='nwords', type=int, default=50, help=_('Number of words to be used.'))
     parser.add_argument('-o', '--output', dest='output', default='Gumby', help=_('Name of crossword.'))
     args = parser.parse_args()
+    if not any([f in args.saveformat for f in filetypes]):
+        # If none of the filetypes matched
+        print("ERROR: Unrecognized File Type!")
+        quit(1)
     gen = Genxword(args.auto, args.mixmode)
     with open(args.infile) as infile:
         gen.wlist(infile, args.nwords)


### PR DESCRIPTION
I've added JSON, CSV, and Text as export types (#14),
a cleaner border for PDF export (#25),
and warnings on incorrect file type in terminal (#27),
as well as instructions for terminal only install (#22).

However, since this uses GTK for rendering images, we don't really cut back that much bloat from the terminal only install.
#13 Is more than a simple modification, so I didn't do that one.

All the other issues (#18 #24 #21) could probably be closed since they're just installation errors (most likely from the users' configurations), and nothing new has been added to those for 2-3 years.